### PR TITLE
Update Groovy to current stable version (4.0.22)

### DIFF
--- a/jsyntrax/pom.xml
+++ b/jsyntrax/pom.xml
@@ -59,9 +59,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
-            <version>3.0.13</version>
+            <version>4.0.22</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>


### PR DESCRIPTION
This PR updates Groovy to the current latest 4.x version. This is intended to resolve https://github.com/asciidoctor/asciidoctor-diagram/issues/467