### PR TITLE
chore: enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,8 @@ updates:
   - dependency-name: org.codehaus.groovy:groovy-eclipse-compiler
     versions:
     - 3.6.0-03
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Adds a `github-actions` package-ecosystem entry to `.github/dependabot.yml` so GitHub Actions workflow dependencies are checked for updates weekly (limit 10 open PRs).

```yaml
  - package-ecosystem: github-actions
    directory: "/"
    schedule:
      interval: weekly
    open-pull-requests-limit: 10
```